### PR TITLE
Fix newline output in /history command

### DIFF
--- a/retrochat_app/ui/command_processor.py
+++ b/retrochat_app/ui/command_processor.py
@@ -178,7 +178,8 @@ def process_command(ui: 'TerminalUI', command_input: str) -> bool:
         history = ui.session_manager.get_conversation_history()
         if not history: ui.console.print("Conversation history is empty for the current session.")
         else:
-            ui.console.print("\\\\nConversation History:")
+            # Display a blank line before the history header
+            ui.console.print("\nConversation History:")
             for msg in history:
                 ui.console.print(f"  {msg['role'].capitalize()}: {msg['content']}")
             ui.console.print("-" * 30)


### PR DESCRIPTION
## Summary
- fix newline escape sequence when printing conversation history

## Testing
- `python3 -m py_compile retrochat_app/ui/command_processor.py`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f4eaefcbc8332bad32119857b649e