### PR TITLE
Add provider header management

### DIFF
--- a/retrochat_app/core/provider_manager.py
+++ b/retrochat_app/core/provider_manager.py
@@ -210,6 +210,35 @@ def select_provider(name: str):
     return False
 
 
+def set_provider_header(name: str, header_key: str, header_value: str) -> bool:
+    """Set or update a header for the specified provider."""
+    index = load_index()
+    for entry in index.get("providers", []):
+        if entry.get("name") == name:
+            file_path = os.path.join(PROVIDERS_DIR, entry.get("file"))
+            try:
+                with open(file_path, "r") as f:
+                    cfg = json.load(f)
+            except Exception as e:
+                logger.error(f"Error reading provider config for {name}: {e}")
+                return False
+
+            if not isinstance(cfg.get("headers"), dict):
+                cfg["headers"] = {}
+
+            cfg["headers"][header_key] = header_value
+
+            try:
+                with open(file_path, "w") as f:
+                    json.dump(cfg, f, indent=4)
+                return True
+            except Exception as e:
+                logger.error(f"Error saving provider config for {name}: {e}")
+                return False
+    logger.error(f"Provider '{name}' not found.")
+    return False
+
+
 def _launch_editor(file_path: str):
     """Launch the system default editor to edit the provider config."""
     system = platform.system()

--- a/retrochat_app/ui/command_processor.py
+++ b/retrochat_app/ui/command_processor.py
@@ -33,7 +33,7 @@ def process_command(ui: 'TerminalUI', command_input: str) -> bool:
     # Provider management commands
     if command == "/provider":
         if not args:
-            ui.console.print("Usage: /provider <list|add|edit|delete|select> [args]")
+            ui.console.print("Usage: /provider <list|add|edit|delete|select|set-header> [args]")
             return False
         sub = args[0].lower()
         # List providers
@@ -93,8 +93,19 @@ def process_command(ui: 'TerminalUI', command_input: str) -> bool:
             else:
                 ui.console.print(f"[red]Failed to select provider '{name}'[/red]")
             return False
+        elif sub == "set-header":
+            if len(args) < 4:
+                ui.console.print("Usage: /provider set-header <name> <header_key> <header_value>")
+                return False
+            name, header_key = args[1], args[2]
+            header_value = " ".join(args[3:])
+            if provider_manager.set_provider_header(name, header_key, header_value):
+                ui.console.print(f"Header '{header_key}' set for provider '{name}'.")
+            else:
+                ui.console.print(f"[red]Failed to set header for provider '{name}'[/red]")
+            return False
         else:
-            ui.console.print(f"Unknown provider command: {sub}. Use list, add, edit, delete, select.")
+            ui.console.print(f"Unknown provider command: {sub}. Use list, add, edit, delete, select, set-header.")
             return False
 
     if command == "/info":

--- a/retrochat_app/ui/display_handler.py
+++ b/retrochat_app/ui/display_handler.py
@@ -42,6 +42,7 @@ def show_help(console: Console):
     console.print("  /provider edit <name>          - Edit an existing provider's configuration in editor.")
     console.print("  /provider delete <name>        - Delete a provider.")
     console.print("  /provider select <name>        - Select a provider as active.")
+    console.print("  /provider set-header <name> <header_key> <header_value> - Set or update a header for a provider.")
     console.print("-" * 30)
 
 def show_system_info(console: Console, llm_client):


### PR DESCRIPTION
## Summary
- add helper to set provider headers
- support `/provider set-header` command
- document command in help

## Testing
- `python -m py_compile retrochat_app/core/provider_manager.py retrochat_app/ui/command_processor.py retrochat_app/ui/display_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6e0b447483328337bcca6e2a7874